### PR TITLE
ul drive rm

### DIFF
--- a/ulcli/commands/drive/cp.py
+++ b/ulcli/commands/drive/cp.py
@@ -31,7 +31,7 @@ from ulsdk.api.drive import (
     put_file_chunk,
 )
 
-from .utils import parse_timestamp_arg, timestamp_in_range
+from .utils import parse_timestamp_arg, timestamp_in_range, is_directory_entry_id
 
 
 CHUNK_SIZE = 96 * 1024 * 1024
@@ -196,14 +196,6 @@ class LocalEntry(Entry):
         path = os.path.join(self._path, dir)
         os.mkdir(path)
         return LocalEntry(path)
-
-
-def is_directory_entry_id(id: str) -> bool:
-    try:
-        assert uuid.UUID(id)
-    except Exception:
-        return False
-    return id.startswith("0500")
 
 
 def get_dir_list_slot(context: RequestContext, id_str: str) -> DriveEntry:

--- a/ulcli/commands/drive/cp.py
+++ b/ulcli/commands/drive/cp.py
@@ -29,6 +29,7 @@ from ulsdk.api.drive import (
     create_entry,
     post_file,
     put_file_chunk,
+    unlink,
 )
 
 from .utils import parse_timestamp_arg, timestamp_in_range, is_directory_entry_id
@@ -102,7 +103,13 @@ def mk_dir(context: RequestContext, parent: uuid.UUID, dir: str) -> ObjectId:
     return summary.id
 
 
-class DriveEntry(Entry):
+class Removable(ABC):
+    @abstractmethod
+    def rm(self):
+        """Remove the entry from the drive"""
+
+
+class DriveEntry(Entry, Removable):
     _oid: uuid.UUID
 
     def __init__(self, context: RequestContext, slot: ListSlot):
@@ -164,6 +171,9 @@ class DriveEntry(Entry):
                 return entry
 
         raise Exception("Created directory was not in directory listing")
+
+    def rm(self):
+        unlink(self._context, str(self._oid))
 
 
 class LocalEntry(Entry):

--- a/ulcli/commands/drive/rm.py
+++ b/ulcli/commands/drive/rm.py
@@ -1,7 +1,28 @@
 # Copyright (c), CommunityLogiq Software
-
+import ulcli.argparser
 from typing import List
+from loguru import logger
+from ulsdk.api.drive import unlink
+from flatbuffer import ulcli
+from ulcli.commands.common import get_api_context
+from .utils import is_directory_entry_id
 
 
 def drive_rm(args: List[str]):
-    raise NotImplementedError
+    parser = ulcli.argparser.ArgumentParser(
+        prog="ul drive rm", description="Remove files/directories from the Drive"
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        help="pattern of files/directories to remove. Please quote all wildcards",
+    )
+
+    parsed = parser.parse_args(args)
+    context = get_api_context(parsed)
+    files = parsed.files
+
+    assert is_directory_entry_id(files)
+    unlink(context, files)
+    logger.info(f"Unlinked {files}")
+    return True

--- a/ulcli/commands/drive/rm.py
+++ b/ulcli/commands/drive/rm.py
@@ -1,17 +1,67 @@
 # Copyright (c), CommunityLogiq Software
-import ulcli.argparser
+import urllib.parse
+
 from typing import List
 from loguru import logger
-from ulsdk.api.drive import unlink
+from ulsdk.api.drive import ls
 from flatbuffer import ulcli
 from ulcli.commands.common import get_api_context
-from .utils import is_directory_entry_id
+from .utils import is_directory_entry_id, get_dir_list_slot, DriveEntry
+from ulsdk.request_context import RequestContext
 
 
-def drive_rm(args: List[str]):
+
+def do_rm_r(context: RequestContext, source: DriveEntry) -> bool:
+    src_entries = source.collect()
+    for src in src_entries:
+        if src.isdir():
+            do_rm_r(context, src)
+        else:
+            logger.info(f"Deleting {src.name()}")
+            src.rm()
+    return True
+
+
+def parse_pattern(context: RequestContext, pattern: str) -> List[DriveEntry]:
+    resolved_files = []
+    if "%" in pattern:
+        pattern = urllib.parse.unquote(pattern)
+
+    if "*" in pattern and not pattern.endswith("*"):
+        raise ValueError("Currently only trailing wildcards are supported")
+
+    splits = pattern.split("/")
+
+    # Drive location is a directory id
+    # e.g., 05006c77-e69f-893e-40d1-842b64c961a5
+    if is_directory_entry_id(splits[0]):
+        if len(splits) > 1:
+            raise Exception(
+                "to reference drive roots use the syntax <guid>:/<path>"
+            )
+
+        resolved_files.append(get_dir_list_slot(context, splits[0]))
+        return resolved_files
+
+    # Dirve location is a directory id followed by a relative path
+    # e.g., 05006c77-e69f-893e-40d1-842b64c961a5:/Dataset upload folder/Transportation/Turning movement counts/*
+    if splits[0].endswith(":") and len(splits[0]) == 37:
+        # remote (drive) path
+        root = splits[0][:-1]
+        path = "/".join(splits[1:])
+
+        entries = ls(context, root, path)
+        slots = entries.slots
+        resolved_files += [DriveEntry(context, entry) for entry in slots]
+
+    return resolved_files
+
+
+def drive_rm(args: List[str]) -> bool:
     parser = ulcli.argparser.ArgumentParser(
         prog="ul drive rm", description="Remove files/directories from the Drive"
     )
+    parser.add_argument("-r", help="recursively delete all subdirectories")
     parser.add_argument(
         "files",
         nargs="+",
@@ -21,8 +71,24 @@ def drive_rm(args: List[str]):
     parsed = parser.parse_args(args)
     context = get_api_context(parsed)
     files = parsed.files
+    entries = parse_pattern(context, files)
 
-    assert is_directory_entry_id(files)
-    unlink(context, files)
-    logger.info(f"Unlinked {files}")
+    # non‑empty directory & recursive
+    # -> delete all content (files/sudirs)
+    if parsed.r:
+        for entry in entries:
+            do_rm_r(context, entry)
+        return True
+
+    # non-empty directory & non-recursive
+    # -> delete only files, keep subdirs
+    for entry in entries:
+        if entry.isdir():
+            logger.warning(
+                f"Skipping deletion of {entry.name()} because it is a directory. Use -r, if you intend to recursively delete directory contents."
+            )
+            continue
+        logger.info(f"Deleting {entry.name()}")
+        entry.rm()
+
     return True

--- a/ulcli/commands/drive/utils.py
+++ b/ulcli/commands/drive/utils.py
@@ -7,6 +7,7 @@ Shared functions for the drive commands
 import datetime
 import re
 from typing import Any
+from uuid import UUID
 
 
 def parse_timestamp_arg(arg: Any) -> int | None:
@@ -31,3 +32,11 @@ def timestamp_in_range(
     if latest_timestamp is not None and ts > latest_timestamp:
         return False
     return True
+
+
+def is_directory_entry_id(id: str) -> bool:
+    try:
+        assert UUID(id)
+    except Exception:
+        return False
+    return id.startswith("0500")


### PR DESCRIPTION
### What
Implement the `ul drive rm` command to delete files/directories from the UL Drive.

---

**File**  
- If the target is a file → delete it and exit.  
- Otherwise, treat it as a directory.

**Empty directory**  
- Delete the directory itself.

**Non-empty, non-recursive delete**  
- If the directory has only files → delete them all, keep the directory.  
- If it has any subdirectories → delete the files, but warn about subdirectories.

**Non-empty, recursive delete (`-r`)**  
- Delete all files and subdirectories.  
- After processing all children, the original directory remains empty (but still exists).