### PR TITLE
Convert milliseconds timestamp to seconds to compare like units

### DIFF
--- a/ulcli/commands/drive/move.py
+++ b/ulcli/commands/drive/move.py
@@ -69,7 +69,7 @@ def do_move(
             latest_timestamp,
         ):
             continue
-
+        # ensure that we don't move the target directory to itself
         if obj_id == target_id:
             breakpoint()
             logger.info(f"Not moving {item.name} ({obj_id}) to {target} as it is the target directory")

--- a/ulcli/commands/drive/move.py
+++ b/ulcli/commands/drive/move.py
@@ -64,7 +64,7 @@ def do_move(
             continue
 
         if not timestamp_in_range(
-            item.time,
+            item.time / 1000, # convert timestamp to seconds
             earliest_timestamp,
             latest_timestamp,
         ):

--- a/ulcli/commands/drive/move.py
+++ b/ulcli/commands/drive/move.py
@@ -71,7 +71,6 @@ def do_move(
             continue
         # ensure that we don't move the target directory to itself
         if obj_id == target_id:
-            breakpoint()
             logger.info(f"Not moving {item.name} ({obj_id}) to {target} as it is the target directory")
             continue
 

--- a/ulcli/commands/drive/move.py
+++ b/ulcli/commands/drive/move.py
@@ -70,7 +70,12 @@ def do_move(
         ):
             continue
 
-        logger.info(f"Moving {item.name} ({id}) to {target} with overwrite={overwrite}")
+        if obj_id == target_id:
+            breakpoint()
+            logger.info(f"Not moving {item.name} ({obj_id}) to {target} as it is the target directory")
+            continue
+
+        logger.info(f"Moving {item.name} to {target} with overwrite={overwrite}")
 
         move_request = MoveRequest(
             None,


### PR DESCRIPTION
Convert the timestamp of drive files returned by ulsdk from milliseconds to seconds. This ensures that all time values are compared in the same unit (seconds).

`ul drive mv -env stage -region us "0500c702-8685-a15e-47e9-b1c57526c651/*" 0500c287-a85e-597c-4a1d-ae8b7395e17c -start 2023-02-22 -end 2025-06-01`

Add check to ensure target does not move into itself.