### PR TITLE
add connect() method to BearerTokenContext

### DIFF
--- a/ulcli/commands/keys.py
+++ b/ulcli/commands/keys.py
@@ -170,6 +170,14 @@ class BearerTokenContext(RequestContext):
     ) -> bytes:
         raise Exception("not implemented")
 
+    def connect(
+        self,
+        path: str,
+        params: Optional[Dict] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
+        raise NotImplementedError("BearerTokenContext does not support websocket connections")
+
 
 def test_profile(profile: str) -> bool:
     from ulsdk.keys import load_key, Environment


### PR DESCRIPTION
today, running `ul keys install` after a fresh ulcli reinstall; I was getting the following error. 

```Traceback (most recent call last):
  File "/home/kyle/work/repos/ul/tools/ulcli/main.py", line 9, in <module>
    ulcli.main()
  File "/home/kyle/.pyenv/versions/ulcli/lib/python3.12/site-packages/ulcli/__init__.py", line 107, in main
    if not instance.run():
           ^^^^^^^^^^^^^^
  File "/home/kyle/.pyenv/versions/ulcli/lib/python3.12/site-packages/ulcli/commands/keys.py", line 466, in run
    return parser.dispatch(sys.argv[2:])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyle/.pyenv/versions/ulcli/lib/python3.12/site-packages/ulcli/cmdparser.py", line 84, in dispatch
    return arg_tuple.fn(self.rest)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyle/.pyenv/versions/ulcli/lib/python3.12/site-packages/ulcli/commands/keys.py", line 425, in install_keys
    while not do_install(parsed_region):
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kyle/.pyenv/versions/ulcli/lib/python3.12/site-packages/ulcli/commands/keys.py", line 396, in do_install
    context = BearerTokenContext(env, region, token, user_id)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Can't instantiate abstract class BearerTokenContext without an implementation for abstract method 'connect'```